### PR TITLE
Implement schedule support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ dependencies = [
  "tapo",
  "tokio",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ chrono = { version = "0.4.41", default-features = false, features = [
 ] }
 log = { version = "0.4.27", features = ["std"] }
 colored = "3.0.0"
+uuid = { version = "1.6.1", features = ["v4"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod config;
 mod devices;
 mod logger;
 mod server;
+mod scheduler;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -102,5 +103,12 @@ async fn inner_main() -> Result<()> {
 
     info!("Now launching server...");
 
-    server::serve(server_config, devices, data_dir.join("sessions.json")).await
+    server::serve(
+        server_config,
+        devices,
+        data_dir.join("sessions.json"),
+        data_dir.join("schedules.json"),
+        data_dir.join("schedule.log"),
+    )
+    .await
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,205 @@
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc, Weekday, Datelike};
+use serde::{Deserialize, Serialize};
+use tokio::{fs, sync::RwLock, time::sleep};
+
+use crate::server::StateData;
+use crate::devices::TapoDeviceInner;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Action {
+    On,
+    Off,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum ScheduleKind {
+    Once {
+        datetime: DateTime<Utc>,
+    },
+    Recurring {
+        weekdays: Vec<Weekday>,
+        time: NaiveTime,
+        end_date: Option<NaiveDate>,
+        exclude_dates: Vec<NaiveDate>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Schedule {
+    pub id: String,
+    pub owner: String,
+    pub device: String,
+    pub action: Action,
+    pub kind: ScheduleKind,
+}
+
+pub struct Scheduler {
+    path: PathBuf,
+    log_path: PathBuf,
+    map: RwLock<HashMap<String, Schedule>>, // id -> schedule
+}
+
+impl Scheduler {
+    pub async fn load(path: PathBuf, log_path: PathBuf) -> Result<Arc<Self>> {
+        let map = if path.exists() {
+            let data = fs::read_to_string(&path)
+                .await
+                .context("Failed to read schedules file")?;
+            serde_json::from_str(&data).context("Failed to parse schedules file")?
+        } else {
+            HashMap::new()
+        };
+
+        Ok(Arc::new(Self { path, log_path, map: RwLock::new(map) }))
+    }
+
+    async fn save(&self, map: &HashMap<String, Schedule>) -> Result<()> {
+        let data = serde_json::to_string(map).unwrap();
+        fs::write(&self.path, data)
+            .await
+            .context("Failed to write schedules file")?;
+        Ok(())
+    }
+
+    pub async fn insert(&self, mut schedule: Schedule) -> Result<String> {
+        let id = uuid::Uuid::new_v4().to_string();
+        schedule.id = id.clone();
+        let mut lock = self.map.write().await;
+        lock.insert(id.clone(), schedule);
+        self.save(&lock).await?;
+        Ok(id)
+    }
+
+    pub async fn update(&self, id: &str, schedule: Schedule) -> Result<()> {
+        let mut lock = self.map.write().await;
+        if lock.contains_key(id) {
+            lock.insert(id.to_string(), schedule);
+            self.save(&lock).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn remove(&self, id: &str) -> Result<()> {
+        let mut lock = self.map.write().await;
+        lock.remove(id);
+        self.save(&lock).await?;
+        Ok(())
+    }
+
+    pub async fn list_owner(&self, owner: &str) -> Vec<Schedule> {
+        let lock = self.map.read().await;
+        lock.values()
+            .filter(|s| s.owner == owner)
+            .cloned()
+            .collect()
+    }
+
+    pub async fn list_all(&self) -> Vec<Schedule> {
+        self.map.read().await.values().cloned().collect()
+    }
+
+    pub async fn run(self: Arc<Self>, state: Arc<StateData>) {
+        loop {
+            self.check(&state).await;
+            sleep(Duration::from_secs(30)).await;
+        }
+    }
+
+    async fn check(&self, state: &StateData) {
+        let now = Utc::now();
+        let mut to_remove = vec![];
+        let map_snapshot = self.map.read().await.clone();
+        for (id, sched) in map_snapshot.iter() {
+            match &sched.kind {
+                ScheduleKind::Once { datetime } => {
+                    if now >= *datetime {
+                        if let Err(e) = execute_action(&sched.action, &sched.device, state).await {
+                            eprintln!("Failed to run schedule {id}: {e}");
+                        } else {
+                            self.log(format!("{} executed {}\n", now, id)).await;
+                        }
+                        to_remove.push(id.clone());
+                    }
+                }
+                ScheduleKind::Recurring { weekdays, time, end_date, exclude_dates } => {
+                    let today = now.date_naive();
+                    if let Some(end) = end_date {
+                        if today > *end { to_remove.push(id.clone()); continue; }
+                    }
+                    if exclude_dates.contains(&today) { continue; }
+                    if !weekdays.contains(&now.weekday()) { continue; }
+                    let now_time = now.time();
+                    if now_time.hour() == time.hour() && now_time.minute() == time.minute() && now_time.second() < 30 {
+                        if let Err(e) = execute_action(&sched.action, &sched.device, state).await {
+                            eprintln!("Failed to run schedule {id}: {e}");
+                        } else {
+                            self.log(format!("{} executed {}\n", now, id)).await;
+                        }
+                    }
+                }
+            }
+        }
+        if !to_remove.is_empty() {
+            let mut lock = self.map.write().await;
+            for id in to_remove { lock.remove(&id); }
+            let _ = self.save(&lock).await;
+        }
+    }
+
+    async fn log(&self, text: String) {
+        if let Ok(mut file) = fs::OpenOptions::new().append(true).create(true).open(&self.log_path).await {
+            use tokio::io::AsyncWriteExt;
+            let _ = file.write_all(text.as_bytes()).await;
+        }
+    }
+}
+
+use chrono::Timelike;
+
+async fn execute_action(action: &Action, device: &str, state: &StateData) -> Result<()> {
+    let device = state.devices.get(device).context("Unknown device")?;
+    device
+        .with_client(async move |client| -> Result<()> {
+            match action {
+                Action::On => match client {
+                    TapoDeviceInner::L510(c) => c.on().await?,
+                    TapoDeviceInner::L520(c) => c.on().await?,
+                    TapoDeviceInner::L610(c) => c.on().await?,
+                    TapoDeviceInner::L530(c) => c.on().await?,
+                    TapoDeviceInner::L535(c) => c.on().await?,
+                    TapoDeviceInner::L630(c) => c.on().await?,
+                    TapoDeviceInner::L900(c) => c.on().await?,
+                    TapoDeviceInner::L920(c) => c.on().await?,
+                    TapoDeviceInner::L930(c) => c.on().await?,
+                    TapoDeviceInner::P100(c) => c.on().await?,
+                    TapoDeviceInner::P105(c) => c.on().await?,
+                    TapoDeviceInner::P110(c) => c.on().await?,
+                    TapoDeviceInner::P110M(c) => c.on().await?,
+                    TapoDeviceInner::P115(c) => c.on().await?,
+                },
+                Action::Off => match client {
+                    TapoDeviceInner::L510(c) => c.off().await?,
+                    TapoDeviceInner::L520(c) => c.off().await?,
+                    TapoDeviceInner::L610(c) => c.off().await?,
+                    TapoDeviceInner::L530(c) => c.off().await?,
+                    TapoDeviceInner::L535(c) => c.off().await?,
+                    TapoDeviceInner::L630(c) => c.off().await?,
+                    TapoDeviceInner::L900(c) => c.off().await?,
+                    TapoDeviceInner::L920(c) => c.off().await?,
+                    TapoDeviceInner::L930(c) => c.off().await?,
+                    TapoDeviceInner::P100(c) => c.off().await?,
+                    TapoDeviceInner::P105(c) => c.off().await?,
+                    TapoDeviceInner::P110(c) => c.off().await?,
+                    TapoDeviceInner::P110M(c) => c.off().await?,
+                    TapoDeviceInner::P115(c) => c.off().await?,
+                },
+            }
+            Ok(())
+        })
+        .await??;
+    Ok(())
+}
+

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -14,13 +14,14 @@ use super::{
 
 #[derive(Deserialize)]
 pub struct LoginData {
+    email: String,
     password: String,
 }
 
 // TODO: fail2ban? rate limiting?
 pub async fn login(
     State(state): State<SharedState>,
-    Json(LoginData { password }): Json<LoginData>,
+    Json(LoginData { email, password }): Json<LoginData>,
 ) -> ApiResult<String> {
     if password != state.auth_password {
         return Err(ApiError::new(
@@ -29,7 +30,7 @@ pub async fn login(
         ));
     }
 
-    let session_id = state.sessions.insert().await?;
+    let session_id = state.sessions.insert(email).await?;
 
     Ok(session_id)
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,13 +15,15 @@ use crate::{
     server::actions::make_router,
 };
 
-use self::{sessions::refresh_session, state::StateData};
+use self::sessions::refresh_session;
 
 mod actions;
 mod auth;
 mod errors;
 mod sessions;
 mod state;
+pub use state::StateData;
+mod schedules;
 
 pub use actions::TapoDeviceType;
 pub use errors::{ApiError, ApiResult};
@@ -32,6 +34,8 @@ pub async fn serve(
     config: ServerConfig,
     devices: Vec<TapoDevice>,
     sessions_file: PathBuf,
+    schedules_file: PathBuf,
+    schedule_log: PathBuf,
 ) -> Result<()> {
     let ServerConfig { port, password } = config;
 
@@ -67,20 +71,28 @@ pub async fn serve(
             AllowOrigin::any(),
         );
 
+    let state = Arc::new(
+        StateData::init(
+            // TODO: hash?
+            auth_password,
+            devices,
+            sessions_file,
+            schedules_file,
+            schedule_log,
+        )
+        .await?,
+    );
+
+    let scheduler_state = state.clone();
+    tokio::spawn(state.scheduler.clone().run(scheduler_state));
+
     let app = Router::new()
         .route("/login", post(auth::login))
         .route("/refresh-session", get(refresh_session))
         .nest("/actions", make_router())
+        .nest("/schedules", schedules::make_router())
         .layer(cors)
-        .with_state(Arc::new(
-            StateData::init(
-                // TODO: hash?
-                auth_password,
-                devices,
-                sessions_file,
-            )
-            .await?,
-        ));
+        .with_state(state);
 
     let addr = format!("0.0.0.0:{port}");
 

--- a/src/server/schedules.rs
+++ b/src/server/schedules.rs
@@ -1,0 +1,107 @@
+use axum::{extract::{Path, State}, routing::{get, post, patch}, Json, Router};
+use axum_extra::TypedHeader;
+use axum_extra::headers::{authorization::Bearer, Authorization};
+use serde::{Deserialize, Serialize};
+use crate::{scheduler::{Schedule, ScheduleKind, Action}, server::{auth::auth, ApiError, ApiResult, SharedState}};
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc, Weekday};
+
+pub fn make_router() -> Router<SharedState> {
+    Router::new()
+        .route("/", post(add_schedule).get(list_schedules))
+        .route("/:id", patch(update_schedule).delete(delete_schedule))
+        .route("/all", get(list_all))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")] 
+struct OnceData { datetime: DateTime<Utc> }
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RecurringData {
+    weekdays: Vec<Weekday>,
+    time: NaiveTime,
+    end_date: Option<NaiveDate>,
+    #[serde(default)]
+    exclude_dates: Vec<NaiveDate>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScheduleInput {
+    device: String,
+    action: String,
+    #[serde(flatten)]
+    kind: KindInput,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+enum KindInput {
+    Once(OnceData),
+    Recurring(RecurringData),
+}
+
+#[derive(Serialize)]
+struct IdResp { status: &'static str, schedule_id: String }
+
+#[derive(Serialize)]
+struct StatusResp { status: &'static str }
+
+async fn add_schedule(
+    auth_header: TypedHeader<Authorization<Bearer>>, 
+    State(state): State<SharedState>,
+    Json(data): Json<ScheduleInput>,
+) -> ApiResult<Json<IdResp>> {
+    let session = auth(auth_header, &state.sessions).await?;
+    let action = match data.action.as_str() { "on" => Action::On, "off" => Action::Off, _ => return Err(ApiError::new(axum::http::StatusCode::BAD_REQUEST, "invalid action")) };
+    let kind = match data.kind {
+        KindInput::Once(o) => ScheduleKind::Once { datetime: o.datetime },
+        KindInput::Recurring(r) => ScheduleKind::Recurring { weekdays: r.weekdays, time: r.time, end_date: r.end_date, exclude_dates: r.exclude_dates },
+    };
+    let schedule = Schedule { id: String::new(), owner: session.email.clone(), device: data.device, action, kind };
+    let id = state.scheduler.insert(schedule).await?;
+    Ok(Json(IdResp{status: "ok", schedule_id: id}))
+}
+
+async fn list_schedules(auth_header: TypedHeader<Authorization<Bearer>>, State(state): State<SharedState>) -> ApiResult<Json<Vec<Schedule>>> {
+    let session = auth(auth_header, &state.sessions).await?;
+    let list = state.scheduler.list_owner(&session.email).await;
+    Ok(Json(list))
+}
+
+async fn list_all(auth_header: TypedHeader<Authorization<Bearer>>, State(state): State<SharedState>) -> ApiResult<Json<Vec<Schedule>>> {
+    let session = auth(auth_header, &state.sessions).await?;
+    if session.email != "admin@yourdomain.com" { return Err(ApiError::new(axum::http::StatusCode::FORBIDDEN, "권한 없음")); }
+    Ok(Json(state.scheduler.list_all().await))
+}
+
+
+async fn update_schedule(
+    auth_header: TypedHeader<Authorization<Bearer>>, 
+    Path(id): Path<String>,
+    State(state): State<SharedState>,
+    Json(update): Json<ScheduleInput>,
+) -> ApiResult<Json<StatusResp>> {
+    let session = auth(auth_header, &state.sessions).await?;
+    let mut schedule = state.scheduler.list_all().await.into_iter().find(|s| s.id==id).ok_or(ApiError::new(axum::http::StatusCode::NOT_FOUND, "not found"))?;
+    if schedule.owner != session.email { return Err(ApiError::new(axum::http::StatusCode::FORBIDDEN, "권한 없음")); }
+    let action = match update.action.as_str() { "on" => Action::On, "off" => Action::Off, _ => return Err(ApiError::new(axum::http::StatusCode::BAD_REQUEST, "invalid action")) };
+    let kind = match update.kind {
+        KindInput::Once(o) => ScheduleKind::Once { datetime: o.datetime },
+        KindInput::Recurring(r) => ScheduleKind::Recurring { weekdays: r.weekdays, time: r.time, end_date: r.end_date, exclude_dates: r.exclude_dates },
+    };
+    schedule.device = update.device;
+    schedule.action = action;
+    schedule.kind = kind;
+    state.scheduler.update(&id, schedule).await?;
+    Ok(Json(StatusResp{status: "updated"}))
+}
+
+async fn delete_schedule(auth_header: TypedHeader<Authorization<Bearer>>, Path(id): Path<String>, State(state): State<SharedState>) -> ApiResult<Json<StatusResp>> {
+    let session = auth(auth_header, &state.sessions).await?;
+    let schedule = state.scheduler.list_all().await.into_iter().find(|s| s.id==id).ok_or(ApiError::new(axum::http::StatusCode::NOT_FOUND, "not found"))?;
+    if schedule.owner != session.email { return Err(ApiError::new(axum::http::StatusCode::FORBIDDEN, "권한 없음")); }
+    state.scheduler.remove(&id).await?;
+    Ok(Json(StatusResp{status:"deleted"}))
+}

--- a/src/server/sessions.rs
+++ b/src/server/sessions.rs
@@ -36,8 +36,8 @@ impl Sessions {
         self.map.read().await.get(id).cloned()
     }
 
-    pub async fn insert(&self) -> Result<String> {
-        let session = Session {};
+    pub async fn insert(&self, email: String) -> Result<String> {
+        let session = Session { email };
 
         let id = Self::_gen_session_id();
 
@@ -75,6 +75,7 @@ impl Sessions {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Session {
+    pub email: String,
     // TODO: permissions? only access to specific bulbs, etc.?
 }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use anyhow::Result;
 
 use crate::devices::TapoDevice;
+use crate::scheduler::Scheduler;
 
 use super::sessions::Sessions;
 
@@ -10,6 +11,7 @@ pub struct StateData {
     pub auth_password: String,
     pub devices: HashMap<String, TapoDevice>,
     pub sessions: Sessions,
+    pub scheduler: std::sync::Arc<Scheduler>,
 }
 
 impl StateData {
@@ -17,6 +19,8 @@ impl StateData {
         auth_password: String,
         devices: Vec<TapoDevice>,
         sessions_file: PathBuf,
+        schedules_file: PathBuf,
+        schedule_log: PathBuf,
     ) -> Result<Self> {
         Ok(Self {
             auth_password,
@@ -25,6 +29,7 @@ impl StateData {
                 .map(|device| (device.name().to_owned(), device))
                 .collect(),
             sessions: Sessions::create(sessions_file).await?,
+            scheduler: Scheduler::load(schedules_file, schedule_log).await?,
         })
     }
 }


### PR DESCRIPTION
## Summary
- add scheduler and schedule types
- add schedule REST endpoints
- update session handling to store email
- wire scheduler into server state

## Testing
- `cargo check`
- `cargo test`