### PR TITLE
Add simple schedule API and scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ dependencies = [
  "tapo",
  "tokio",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ chrono = { version = "0.4.41", default-features = false, features = [
 ] }
 log = { version = "0.4.27", features = ["std"] }
 colored = "3.0.0"
+uuid = { version = "1.4.1", features = ["v4"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,5 +102,12 @@ async fn inner_main() -> Result<()> {
 
     info!("Now launching server...");
 
-    server::serve(server_config, devices, data_dir.join("sessions.json")).await
+    server::serve(
+        server_config,
+        devices,
+        data_dir.join("sessions.json"),
+        data_dir.join("schedules.json"),
+        data_dir.join("schedule.log"),
+    )
+    .await
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,13 +15,20 @@ use crate::{
     server::actions::make_router,
 };
 
-use self::{sessions::refresh_session, state::StateData};
+use self::{
+    sessions::refresh_session,
+    state::StateData,
+    schedules::{scheduler_loop},
+    schedules_api::router as schedules_router,
+};
 
 mod actions;
 mod auth;
 mod errors;
 mod sessions;
 mod state;
+mod schedules;
+mod schedules_api;
 
 pub use actions::TapoDeviceType;
 pub use errors::{ApiError, ApiResult};
@@ -32,6 +39,8 @@ pub async fn serve(
     config: ServerConfig,
     devices: Vec<TapoDevice>,
     sessions_file: PathBuf,
+    schedules_file: PathBuf,
+    schedule_log: PathBuf,
 ) -> Result<()> {
     let ServerConfig { port, password } = config;
 
@@ -67,20 +76,26 @@ pub async fn serve(
             AllowOrigin::any(),
         );
 
+    let state = Arc::new(
+        StateData::init(
+            auth_password,
+            devices,
+            sessions_file,
+            schedules_file,
+            schedule_log,
+        )
+        .await?,
+    );
+
+    tokio::spawn(scheduler_loop(state.clone()));
+
     let app = Router::new()
         .route("/login", post(auth::login))
         .route("/refresh-session", get(refresh_session))
         .nest("/actions", make_router())
+        .merge(schedules_router())
         .layer(cors)
-        .with_state(Arc::new(
-            StateData::init(
-                // TODO: hash?
-                auth_password,
-                devices,
-                sessions_file,
-            )
-            .await?,
-        ));
+        .with_state(state);
 
     let addr = format!("0.0.0.0:{port}");
 

--- a/src/server/schedules.rs
+++ b/src/server/schedules.rs
@@ -1,0 +1,219 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{NaiveDate, NaiveTime, Datelike, Local};
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use uuid::Uuid;
+
+use crate::devices::TapoDeviceInner;
+
+use super::{ApiError, ApiResult, SharedState};
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum ScheduleType {
+    Single,
+    Recurring,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Schedule {
+    pub id: String,
+    pub device_id: String,
+    pub action: String,
+    pub schedule_type: ScheduleType,
+    pub time: String,
+    #[serde(default)]
+    pub days_of_week: Vec<String>,
+    #[serde(default)]
+    pub exclude_dates: Vec<String>,
+    pub end_date: Option<String>,
+    pub owner: String,
+}
+
+impl Schedule {
+    pub fn new_single(device_id: String, action: String, time: NaiveTime) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            device_id,
+            action,
+            schedule_type: ScheduleType::Single,
+            time: time.format("%H:%M").to_string(),
+            days_of_week: vec![],
+            exclude_dates: vec![],
+            end_date: None,
+            owner: "admin@yourdomain.com".into(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ScheduleStore {
+    path: PathBuf,
+    pub schedules: HashMap<String, Schedule>,
+}
+
+impl ScheduleStore {
+    pub async fn load(path: PathBuf) -> Result<Self> {
+        let schedules = if path.exists() {
+            let data = fs::read_to_string(&path)
+                .await
+                .context("Failed to read schedules file")?;
+            serde_json::from_str(&data).context("Failed to parse schedules file")?
+        } else {
+            HashMap::new()
+        };
+
+        Ok(Self { path, schedules })
+    }
+
+    pub async fn save(&self) -> Result<()> {
+        let data = serde_json::to_string(&self.schedules).unwrap();
+        fs::write(&self.path, &data)
+            .await
+            .context("Failed to save schedules file")?
+            ;
+        Ok(())
+    }
+
+    pub async fn insert(&mut self, schedule: Schedule) -> Result<String> {
+        let id = schedule.id.clone();
+        self.schedules.insert(id.clone(), schedule);
+        self.save().await?;
+        Ok(id)
+    }
+
+    pub async fn update(&mut self, id: &str, partial: ScheduleUpdate) -> Result<()> {
+        let Some(schedule) = self.schedules.get_mut(id) else { return Err(anyhow::anyhow!("schedule not found")); };
+        if let Some(time) = partial.time {
+            schedule.time = time;
+        }
+        if let Some(days) = partial.days_of_week {
+            schedule.days_of_week = days;
+        }
+        if let Some(exclude) = partial.exclude_dates {
+            schedule.exclude_dates = exclude;
+        }
+        if let Some(end_date) = partial.end_date {
+            schedule.end_date = Some(end_date);
+        }
+        if let Some(action) = partial.action {
+            schedule.action = action;
+        }
+        self.save().await
+    }
+
+    pub async fn delete(&mut self, id: &str) -> Result<()> {
+        self.schedules.remove(id);
+        self.save().await
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ScheduleUpdate {
+    pub time: Option<String>,
+    pub days_of_week: Option<Vec<String>>,
+    pub exclude_dates: Option<Vec<String>>,
+    pub end_date: Option<String>,
+    pub action: Option<String>,
+}
+
+pub async fn scheduler_loop(state: SharedState) {
+    loop {
+        check_schedules(&state).await;
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+    }
+}
+
+async fn check_schedules(state: &SharedState) {
+    let now = Local::now();
+    let time_str = now.format("%H:%M").to_string();
+    let date_str = now.format("%Y-%m-%d").to_string();
+    let weekday = now.format("%a").to_string();
+    let mut to_run = vec![];
+
+    {
+        let store = state.schedules.lock().await;
+        for sched in store.schedules.values() {
+            if sched.time != time_str { continue; }
+            if sched.exclude_dates.iter().any(|d| d == &date_str) { continue; }
+            match sched.schedule_type {
+                ScheduleType::Single => {
+                    if date_str == sched.end_date.clone().unwrap_or_default() {
+                        to_run.push(sched.clone());
+                    }
+                }
+                ScheduleType::Recurring => {
+                    if sched.days_of_week.iter().any(|d| d == &weekday) {
+                        if let Some(end) = &sched.end_date {
+                            if date_str > *end { continue; }
+                        }
+                        to_run.push(sched.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    for sched in to_run {
+        if let Some(device) = state.devices.get(&sched.device_id) {
+            let action = sched.action.clone();
+            device.with_client(async move |client| {
+                match action.as_str() {
+                    "on" => match client {
+                        TapoDeviceInner::L510(c) => c.on().await?,
+                        TapoDeviceInner::L520(c) => c.on().await?,
+                        TapoDeviceInner::L530(c) => c.on().await?,
+                        TapoDeviceInner::L535(c) => c.on().await?,
+                        TapoDeviceInner::L610(c) => c.on().await?,
+                        TapoDeviceInner::L630(c) => c.on().await?,
+                        TapoDeviceInner::L900(c) => c.on().await?,
+                        TapoDeviceInner::L920(c) => c.on().await?,
+                        TapoDeviceInner::L930(c) => c.on().await?,
+                        TapoDeviceInner::P100(c) => c.on().await?,
+                        TapoDeviceInner::P105(c) => c.on().await?,
+                        TapoDeviceInner::P110(c) => c.on().await?,
+                        TapoDeviceInner::P110M(c) => c.on().await?,
+                        TapoDeviceInner::P115(c) => c.on().await?,
+                    },
+                    "off" => match client {
+                        TapoDeviceInner::L510(c) => c.off().await?,
+                        TapoDeviceInner::L520(c) => c.off().await?,
+                        TapoDeviceInner::L530(c) => c.off().await?,
+                        TapoDeviceInner::L535(c) => c.off().await?,
+                        TapoDeviceInner::L610(c) => c.off().await?,
+                        TapoDeviceInner::L630(c) => c.off().await?,
+                        TapoDeviceInner::L900(c) => c.off().await?,
+                        TapoDeviceInner::L920(c) => c.off().await?,
+                        TapoDeviceInner::L930(c) => c.off().await?,
+                        TapoDeviceInner::P100(c) => c.off().await?,
+                        TapoDeviceInner::P105(c) => c.off().await?,
+                        TapoDeviceInner::P110(c) => c.off().await?,
+                        TapoDeviceInner::P110M(c) => c.off().await?,
+                        TapoDeviceInner::P115(c) => c.off().await?,
+                    },
+                    _ => {}
+                }
+                Ok::<(), anyhow::Error>(())
+            }).await.ok();
+        }
+        let log_line = format!(
+            "[{}] 예약 실행: ID={} 디바이스={} 동작={}\n",
+            now.to_rfc3339(),
+            sched.id,
+            sched.device_id,
+            sched.action.to_uppercase()
+        );
+        if let Ok(mut f) = fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&state.schedule_log)
+            .await
+        {
+            use tokio::io::AsyncWriteExt;
+            let _ = f.write_all(log_line.as_bytes()).await;
+        }
+    }
+}
+

--- a/src/server/schedules_api.rs
+++ b/src/server/schedules_api.rs
@@ -1,0 +1,83 @@
+use axum::{extract::{Path, State}, routing::{get, post, patch, delete}, Json, Router};
+use axum_extra::{TypedHeader, headers::{authorization::Bearer, Authorization}};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::{auth::auth, ApiResult, SharedState};
+use crate::server::schedules::{Schedule, ScheduleUpdate, ScheduleType};
+
+#[derive(Deserialize)]
+pub struct ScheduleInput {
+    pub device_id: String,
+    pub action: String,
+    pub schedule_type: ScheduleType,
+    pub time: String,
+    #[serde(default)]
+    pub days_of_week: Vec<String>,
+    #[serde(default)]
+    pub exclude_dates: Vec<String>,
+    pub end_date: Option<String>,
+}
+
+pub fn router() -> Router<SharedState> {
+    Router::new()
+        .route("/schedules", post(add_schedule).get(list_schedules))
+        .route("/schedules/all", get(list_schedules))
+        .route("/schedules/:id", patch(update_schedule).delete(delete_schedule))
+}
+
+async fn add_schedule(
+    auth_header: TypedHeader<Authorization<Bearer>>,
+    State(state): State<SharedState>,
+    Json(input): Json<ScheduleInput>,
+) -> ApiResult<Json<String>> {
+    auth(auth_header, &state.sessions).await?;
+    let mut store = state.schedules_mut().await;
+    let schedule = Schedule {
+        id: Uuid::new_v4().to_string(),
+        device_id: input.device_id,
+        action: input.action,
+        schedule_type: input.schedule_type,
+        time: input.time,
+        days_of_week: input.days_of_week,
+        exclude_dates: input.exclude_dates,
+        end_date: input.end_date,
+        owner: "admin@yourdomain.com".into(),
+    };
+    let id = store.insert(schedule).await?;
+    Ok(Json(id))
+}
+
+async fn list_schedules(
+    auth_header: TypedHeader<Authorization<Bearer>>,
+    State(state): State<SharedState>,
+) -> ApiResult<Json<Vec<Schedule>>> {
+    auth(auth_header, &state.sessions).await?;
+    let store = state.schedules.lock().await;
+    let schedules = store.schedules.values().cloned().collect();
+    Ok(Json(schedules))
+}
+
+async fn update_schedule(
+    auth_header: TypedHeader<Authorization<Bearer>>,
+    Path(id): Path<String>,
+    State(state): State<SharedState>,
+    Json(update): Json<ScheduleUpdate>,
+) -> ApiResult<()> {
+    auth(auth_header, &state.sessions).await?;
+    let mut store = state.schedules_mut().await;
+    store.update(&id, update).await?;
+    Ok(())
+}
+
+async fn delete_schedule(
+    auth_header: TypedHeader<Authorization<Bearer>>,
+    Path(id): Path<String>,
+    State(state): State<SharedState>,
+) -> ApiResult<()> {
+    auth(auth_header, &state.sessions).await?;
+    let mut store = state.schedules_mut().await;
+    store.delete(&id).await?;
+    Ok(())
+}
+

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -4,12 +4,14 @@ use anyhow::Result;
 
 use crate::devices::TapoDevice;
 
-use super::sessions::Sessions;
+use super::{sessions::Sessions, schedules::ScheduleStore};
 
 pub struct StateData {
     pub auth_password: String,
     pub devices: HashMap<String, TapoDevice>,
     pub sessions: Sessions,
+    pub schedules: tokio::sync::Mutex<ScheduleStore>,
+    pub schedule_log: PathBuf,
 }
 
 impl StateData {
@@ -17,6 +19,8 @@ impl StateData {
         auth_password: String,
         devices: Vec<TapoDevice>,
         sessions_file: PathBuf,
+        schedules_file: PathBuf,
+        schedule_log: PathBuf,
     ) -> Result<Self> {
         Ok(Self {
             auth_password,
@@ -25,6 +29,12 @@ impl StateData {
                 .map(|device| (device.name().to_owned(), device))
                 .collect(),
             sessions: Sessions::create(sessions_file).await?,
+            schedules: tokio::sync::Mutex::new(ScheduleStore::load(schedules_file).await?),
+            schedule_log,
         })
+    }
+
+    pub async fn schedules_mut(&self) -> tokio::sync::MutexGuard<'_, ScheduleStore> {
+        self.schedules.lock().await
     }
 }


### PR DESCRIPTION
## Summary
- add schedule management with recurring options
- spawn a scheduler loop to run device actions
- expose REST routes under `/schedules`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68653f5e1c24832e81fc09c0f2cf36b2